### PR TITLE
#185 [fix] unfollow, block 서버 통신에 따른 친구 목록 갱신 시점 수정

### DIFF
--- a/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookShelfViewModel.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookShelfViewModel.kt
@@ -57,10 +57,10 @@ class BookShelfViewModel @Inject constructor(
     private val _isFriendServerStatus = MutableLiveData<Boolean>()
     val isFriendServerStatus: LiveData<Boolean> = _isFriendServerStatus
 
-    private val _isUnfollowStatus = MutableLiveData<Boolean>()
+    private val _isUnfollowStatus = MutableLiveData<Boolean>(false)
     val isUnfollowStatus: LiveData<Boolean> = _isUnfollowStatus
 
-    private val _isBlockStatus = MutableLiveData<Boolean>()
+    private val _isBlockStatus = MutableLiveData<Boolean>(false)
     val isBlockStatus: LiveData<Boolean> = _isBlockStatus
 
     private lateinit var userNickname: String
@@ -95,6 +95,8 @@ class BookShelfViewModel @Inject constructor(
                     _userData.value = response.myIntro
                     _isMyServerStatus.value = true
                     _isFriendServerStatus.value = false
+                    _isUnfollowStatus.value = false
+                    _isBlockStatus.value = false
                 }.onFailure { throwable ->
                     Timber.e("$throwable")
                     _isMyServerStatus.value = false
@@ -121,7 +123,7 @@ class BookShelfViewModel @Inject constructor(
                 }.onFailure { throwable ->
                     Timber.e("$throwable")
                     _isFriendServerStatus.value = false
-                    _isMyServerStatus.value = true
+                    _isMyServerStatus.value = false
                 }
         }
     }
@@ -152,7 +154,7 @@ class BookShelfViewModel @Inject constructor(
 
     private fun updateFriendState(): Boolean {
         return requireNotNull(_friendUserData.value).contains(
-            _userId!!.value?.let { userId ->
+            _userId.value?.let { userId ->
                 FriendList(
                     userId,
                     userNickname,

--- a/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookshelfFragment.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookshelfFragment.kt
@@ -95,6 +95,18 @@ class BookshelfFragment : BindingFragment<FragmentBookshelfBinding>(R.layout.fra
                 updateToMyShelf()
             }
         }
+
+        viewModel.isBlockStatus.observe(viewLifecycleOwner) { success ->
+            if (success) {
+                updateToMyShelf()
+            }
+        }
+
+        viewModel.isUnfollowStatus.observe(viewLifecycleOwner) { success ->
+            if (success) {
+                updateToMyShelf()
+            }
+        }
     }
 
     private fun initDataObserver() {
@@ -226,7 +238,6 @@ class BookshelfFragment : BindingFragment<FragmentBookshelfBinding>(R.layout.fra
                 WarningDialogFragment.CONFIRM_ACTION,
                 ConfirmClickListener(confirmAction = {
                     viewModel.postUnfollow()
-                    updateToMyShelf()
                 })
             )
         }.show(childFragmentManager, WarningDialogFragment.DIALOG_WARNING)
@@ -242,7 +253,6 @@ class BookshelfFragment : BindingFragment<FragmentBookshelfBinding>(R.layout.fra
                 WarningDialogFragment.CONFIRM_ACTION,
                 ConfirmClickListener(confirmAction = {
                     viewModel.postBlock()
-                    updateToMyShelf()
                 })
             )
         }.show(childFragmentManager, BlockDialog.TAG)


### PR DESCRIPTION
관련 이슈
- closed #185 

작업 사진/동영상 (선택)
-

https://user-images.githubusercontent.com/91793891/230903627-3530c98e-5f5e-44e5-ae8d-c46f4bd37dc5.mp4



작업한 내용
- 서버랑 통신 성공하면 내 책장이랑 통신하도록 바꿨습니다!

PR 포인트
- 서버 통신 상태 처리
