### PR TITLE
#208 [fix] 유저 프로필 null처리

### DIFF
--- a/app/src/main/java/com/sopt/peekabookaos/data/entity/response/SearchUserResponse.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/data/entity/response/SearchUserResponse.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 data class SearchUserResponse(
     val friendId: Int,
     val nickname: String,
-    val profileImage: String,
+    val profileImage: String?,
     val isFollowed: Boolean,
     val isBlocked: Boolean
 ) {

--- a/app/src/main/java/com/sopt/peekabookaos/domain/entity/User.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/domain/entity/User.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
 data class User(
     val id: Int = -1,
     val nickname: String = "",
-    val profileImage: String = "",
+    val profileImage: String? = null,
     val intro: String = "",
     val isFollowed: Boolean = false,
     val isBlocked: Boolean = false

--- a/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookShelfViewModel.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookShelfViewModel.kt
@@ -85,76 +85,76 @@ class BookShelfViewModel @Inject constructor(
 
     fun getMyShelfData() {
         viewModelScope.launch {
-            getMyShelfUseCase().onSuccess { response ->
-                _pickData.value = response.picks
-                _bookTotalNum.value = response.bookTotalNum
-                _shelfData.value = response.books
-                _friendUserData.value = response.user
-                _userData.value = response.myIntro
-                _isMyServerStatus.value = true
-                _isFriendServerStatus.value = false
-                _isUnfollowStatus.value = false
-                _isBlockStatus.value = false
-            }.onFailure { throwable ->
-                Timber.e("$throwable")
-                _isMyServerStatus.value = false
-                _isFriendServerStatus.value = false
-            }
+            getMyShelfUseCase()
+                .onSuccess { response ->
+                    _pickData.value = response.picks
+                    _bookTotalNum.value = response.bookTotalNum
+                    _shelfData.value = response.books
+                    _friendUserData.value = response.user
+                    _userData.value = response.myIntro
+                    _isMyServerStatus.value = true
+                    _isFriendServerStatus.value = false
+                    _isUnfollowStatus.value = false
+                    _isBlockStatus.value = false
+                }.onFailure { throwable ->
+                    Timber.e("$throwable")
+                    _isMyServerStatus.value = false
+                    _isFriendServerStatus.value = false
+                }
         }
     }
 
     fun getFriendShelfData() {
         viewModelScope.launch {
-            getFriendShelfUseCase(requireNotNull(userId.value)).onSuccess { response ->
-                _friendUserData.value = response.user
-                if (updateFriendState()) {
-                    _friendData.value = response.friendIntro
-                    _pickData.value = response.picks
-                    _bookTotalNum.value = response.bookTotalNum
-                    _shelfData.value = response.books
-                    _isFriendServerStatus.value = true
+            getFriendShelfUseCase(requireNotNull(userId.value))
+                .onSuccess { response ->
+                    _friendUserData.value = response.user
+                    if (updateFriendState()) {
+                        _friendData.value = response.friendIntro
+                        _pickData.value = response.picks
+                        _bookTotalNum.value = response.bookTotalNum
+                        _shelfData.value = response.books
+                        _isFriendServerStatus.value = true
+                        _isMyServerStatus.value = false
+                    } else {
+                        getMyShelfData()
+                    }
+                }.onFailure { throwable ->
+                    Timber.e("$throwable")
+                    _isFriendServerStatus.value = false
                     _isMyServerStatus.value = false
-                } else {
-                    getMyShelfData()
                 }
-            }.onFailure { throwable ->
-                Timber.e("$throwable")
-                _isFriendServerStatus.value = false
-                _isMyServerStatus.value = false
-            }
         }
     }
 
     fun postUnfollow() {
         viewModelScope.launch {
-            deleteFollowUseCase(requireNotNull(userId.value)).onSuccess { response ->
-                _isUnfollowStatus.value = response
-            }.onFailure { throwable ->
-                Timber.e("$throwable")
-                _isUnfollowStatus.value = false
-            }
+            deleteFollowUseCase(requireNotNull(userId.value))
+                .onSuccess { response ->
+                    _isUnfollowStatus.value = response
+                }.onFailure { throwable ->
+                    Timber.e("$throwable")
+                    _isUnfollowStatus.value = false
+                }
         }
     }
 
     fun postBlock() {
         viewModelScope.launch {
-            postBlockUseCase(requireNotNull(userId.value)).onSuccess { response ->
-                _isBlockStatus.value = response
-            }.onFailure { throwable ->
-                Timber.e("$throwable")
-                _isBlockStatus.value = false
-            }
+            postBlockUseCase(requireNotNull(userId.value))
+                .onSuccess { response ->
+                    _isBlockStatus.value = response
+                }.onFailure { throwable ->
+                    Timber.e("$throwable")
+                    _isBlockStatus.value = false
+                }
         }
     }
 
     private fun updateFriendState(): Boolean {
         return requireNotNull(_friendUserData.value).contains(
             _userId.value?.let { userId ->
-                User(
-                    userId,
-                    userNickname,
-                    userProfileImage
-                )
+                User(userId, userNickname, userProfileImage)
             }
         )
     }

--- a/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookShelfViewModel.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/presentation/bookshelf/BookShelfViewModel.kt
@@ -63,7 +63,7 @@ class BookShelfViewModel @Inject constructor(
     val isBlockStatus: LiveData<Boolean> = _isBlockStatus
 
     private lateinit var userNickname: String
-    private lateinit var userProfileImage: String
+    private var userProfileImage: String? = null
 
     init {
         getMyShelfData()
@@ -85,69 +85,65 @@ class BookShelfViewModel @Inject constructor(
 
     fun getMyShelfData() {
         viewModelScope.launch {
-            getMyShelfUseCase()
-                .onSuccess { response ->
-                    _pickData.value = response.picks
-                    _bookTotalNum.value = response.bookTotalNum
-                    _shelfData.value = response.books
-                    _friendUserData.value = response.user
-                    _userData.value = response.myIntro
-                    _isMyServerStatus.value = true
-                    _isFriendServerStatus.value = false
-                    _isUnfollowStatus.value = false
-                    _isBlockStatus.value = false
-                }.onFailure { throwable ->
-                    Timber.e("$throwable")
-                    _isMyServerStatus.value = false
-                    _isFriendServerStatus.value = false
-                }
+            getMyShelfUseCase().onSuccess { response ->
+                _pickData.value = response.picks
+                _bookTotalNum.value = response.bookTotalNum
+                _shelfData.value = response.books
+                _friendUserData.value = response.user
+                _userData.value = response.myIntro
+                _isMyServerStatus.value = true
+                _isFriendServerStatus.value = false
+                _isUnfollowStatus.value = false
+                _isBlockStatus.value = false
+            }.onFailure { throwable ->
+                Timber.e("$throwable")
+                _isMyServerStatus.value = false
+                _isFriendServerStatus.value = false
+            }
         }
     }
 
     fun getFriendShelfData() {
         viewModelScope.launch {
-            getFriendShelfUseCase(requireNotNull(userId.value))
-                .onSuccess { response ->
-                    _friendUserData.value = response.user
-                    if (updateFriendState()) {
-                        _friendData.value = response.friendIntro
-                        _pickData.value = response.picks
-                        _bookTotalNum.value = response.bookTotalNum
-                        _shelfData.value = response.books
-                        _isFriendServerStatus.value = true
-                        _isMyServerStatus.value = false
-                    } else {
-                        getMyShelfData()
-                    }
-                }.onFailure { throwable ->
-                    Timber.e("$throwable")
-                    _isFriendServerStatus.value = false
+            getFriendShelfUseCase(requireNotNull(userId.value)).onSuccess { response ->
+                _friendUserData.value = response.user
+                if (updateFriendState()) {
+                    _friendData.value = response.friendIntro
+                    _pickData.value = response.picks
+                    _bookTotalNum.value = response.bookTotalNum
+                    _shelfData.value = response.books
+                    _isFriendServerStatus.value = true
                     _isMyServerStatus.value = false
+                } else {
+                    getMyShelfData()
                 }
+            }.onFailure { throwable ->
+                Timber.e("$throwable")
+                _isFriendServerStatus.value = false
+                _isMyServerStatus.value = false
+            }
         }
     }
 
     fun postUnfollow() {
         viewModelScope.launch {
-            deleteFollowUseCase(requireNotNull(userId.value))
-                .onSuccess { response ->
-                    _isUnfollowStatus.value = response
-                }.onFailure { throwable ->
-                    Timber.e("$throwable")
-                    _isUnfollowStatus.value = false
-                }
+            deleteFollowUseCase(requireNotNull(userId.value)).onSuccess { response ->
+                _isUnfollowStatus.value = response
+            }.onFailure { throwable ->
+                Timber.e("$throwable")
+                _isUnfollowStatus.value = false
+            }
         }
     }
 
     fun postBlock() {
         viewModelScope.launch {
-            postBlockUseCase(requireNotNull(userId.value))
-                .onSuccess { response ->
-                    _isBlockStatus.value = response
-                }.onFailure { throwable ->
-                    Timber.e("$throwable")
-                    _isBlockStatus.value = false
-                }
+            postBlockUseCase(requireNotNull(userId.value)).onSuccess { response ->
+                _isBlockStatus.value = response
+            }.onFailure { throwable ->
+                Timber.e("$throwable")
+                _isBlockStatus.value = false
+            }
         }
     }
 

--- a/app/src/main/java/com/sopt/peekabookaos/util/binding/BindingAdapter.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/util/binding/BindingAdapter.kt
@@ -24,6 +24,11 @@ object BindingAdapter {
         this.let {
             Glide.with(context)
                 .load(imgUrl)
+                .apply {
+                    if (imgUrl == null) {
+                        placeholder(R.drawable.ic_profile_default)
+                    }
+                }
                 .circleCrop()
                 .into(this)
         }

--- a/app/src/main/res/drawable/ic_profile_default.xml
+++ b/app/src/main/res/drawable/ic_profile_default.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="81dp"
+    android:height="80dp"
+    android:viewportWidth="81"
+    android:viewportHeight="80">
+  <path
+      android:pathData="M40.5,40m-40,0a40,40 0,1 1,80 0a40,40 0,1 1,-80 0"
+      android:fillColor="#EDECDF"/>
+  <path
+      android:pathData="M40.5,40m-40,0a40,40 0,1 1,80 0a40,40 0,1 1,-80 0"
+      android:fillColor="#8E8E8E"
+      android:fillAlpha="0.6"/>
+  <path
+      android:pathData="M13.594,69.598C15.594,56.537 26.879,46.531 40.499,46.531C54.12,46.531 65.406,56.539 67.404,69.601C60.3,76.062 50.861,80 40.501,80C30.14,80 20.699,76.06 13.594,69.598ZM40.745,42.902C48.184,42.902 54.215,36.874 54.215,29.431C54.215,21.992 48.184,15.961 40.745,15.961C33.306,15.961 27.275,21.992 27.275,29.431C27.247,36.846 33.232,42.877 40.646,42.902H40.745Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
관련 이슈
- closed #208 

작업 사진/동영상 (선택)
- x

작업한 내용
- 바인딩 어댑터에서 imgUrl null처리

PR 포인트
- 바인딩 어댑터에 url이 null로 들어왔을 경우 기본 이미지 띄우는 것으로 처리했습니다. 그래서 님들은 로직상으로는 따로 null처리 할 필요 없고 데이터 단 Entity와 도메인 단 Entity만 String?으로 바꿔주면 될 것 같습니다! @stellar-halo @hajeong67 
- `ic_profile_default`로 디폴트 이미지 박았습니다! @stellar-halo 강희는 내꺼 머지되면 기존에 사용했던 디폴트 이미지 지우고 이걸로 통일해서 쓰면 될 것 같아요
- `User`의 profileImage를 String?으로 바꿔서 @stellar-halo 강희 BookShelf의 변수를 lateinit var에서 그냥 var로 바꿔줬습니다! 확인해주세요
