### PR TITLE
#250 [QA] userinput 이미지 90도 회전 방지

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,9 @@ dependencies {
     // kakao login
     implementation "com.kakao.sdk:v2-user:2.11.0"
 
+    // exifinterface
+    implementation "androidx.exifinterface:exifinterface:1.3.6"
+
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.9.0'

--- a/app/src/main/java/com/sopt/peekabookaos/util/ContentUriRequestBody.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/util/ContentUriRequestBody.kt
@@ -60,6 +60,7 @@ class ContentUriRequestBody(context: Context, private val name: String, private 
     }
 
     fun compressBitmap(): MultipartBody.Part {
+        bitmap = ImageUtil.getOrientationOfImage(uri, bitmap, contentResolver)
         bitmap.compress(Bitmap.CompressFormat.JPEG, 20, byteArrayOutputStream)
         requestBody = create("image/jpg".toMediaTypeOrNull(), byteArrayOutputStream.toByteArray())
         uploadFile = MultipartBody.Part.createFormData(name, getFileName(), requestBody)

--- a/app/src/main/java/com/sopt/peekabookaos/util/ImageUtil.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/util/ImageUtil.kt
@@ -1,10 +1,15 @@
 package com.sopt.peekabookaos.util
 
+import android.content.ContentResolver
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
 import android.net.Uri
+import android.os.Build
 import android.provider.MediaStore
+import androidx.annotation.RequiresApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
@@ -28,7 +33,32 @@ object ImageUtil {
     fun getImageUri(context: Context, bitmap: Bitmap): Uri {
         val bytes = ByteArrayOutputStream()
         bitmap.compress(Bitmap.CompressFormat.JPEG, 100, bytes)
-        val path = MediaStore.Images.Media.insertImage(context.contentResolver, bitmap, "Title", null)
+        val path =
+            MediaStore.Images.Media.insertImage(context.contentResolver, bitmap, "Title", null)
         return Uri.parse(path)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    fun getOrientationOfImage(uri: Uri, bitmap: Bitmap, cr: ContentResolver): Bitmap {
+        val inputStream = cr.openInputStream(uri)
+        val matrix = Matrix()
+        val exif: ExifInterface? = try {
+            ExifInterface(inputStream!!)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return bitmap
+        }
+        inputStream.close()
+
+        val orientation =
+            exif?.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        if (orientation != -1) {
+            when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90F)
+                ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180F)
+                ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270F)
+            }
+        }
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
     }
 }


### PR DESCRIPTION
관련 이슈
- closed #250 

작업 사진/동영상 (선택)
- 생략,, 한 번 각자의 핸드폰에서 해봐주시겠어요?

작업한 내용
- 사진 찍기로 이미지 업로드하는 경우 90도 회전을 막아보았습니다

PR 포인트
- exif를 이용해서 다시 원래대로 회전하는 함수 ImageUtil에 getOrientationOfImage로 추가했어요
- ContentUrlRequestBody에 compressBitmap 함수 안에서 위의 함수를 이용해 새로운 bitmap으로 바꿔치기 했습니다.
