### PR TITLE
#263 [fix] 28이하 기기에서 프로필 수정뷰 진입 막는 분리처리

### DIFF
--- a/app/src/main/java/com/sopt/peekabookaos/presentation/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/presentation/myPage/MyPageFragment.kt
@@ -5,13 +5,13 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.fragment.app.viewModels
 import com.sopt.peekabookaos.R
 import com.sopt.peekabookaos.databinding.FragmentMyPageBinding
 import com.sopt.peekabookaos.presentation.block.BlockedUserActivity
 import com.sopt.peekabookaos.presentation.profileModify.ProfileModifyActivity
 import com.sopt.peekabookaos.presentation.withdraw.WithdrawActivity
+import com.sopt.peekabookaos.util.ToastMessageUtil.showToast
 import com.sopt.peekabookaos.util.binding.BindingFragment
 import com.sopt.peekabookaos.util.extensions.setSingleOnClickListener
 import dagger.hilt.android.AndroidEntryPoint
@@ -58,7 +58,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     private fun initModifyClickListener() {
         binding.ivMyPageEdit.setSingleOnClickListener {
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
-                Toast.makeText(requireContext(), "기능 준비 중이에요.", Toast.LENGTH_SHORT).show()
+                showToast(requireContext(), getString(R.string.my_page_28_donot_modify))
             } else {
                 Intent(requireActivity(), ProfileModifyActivity::class.java).apply {
                     putExtra(USER_INFO, myPageViewModel.userData.value)

--- a/app/src/main/java/com/sopt/peekabookaos/presentation/myPage/MyPageFragment.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/presentation/myPage/MyPageFragment.kt
@@ -2,8 +2,10 @@ package com.sopt.peekabookaos.presentation.myPage
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import com.sopt.peekabookaos.R
 import com.sopt.peekabookaos.databinding.FragmentMyPageBinding
@@ -55,10 +57,14 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
 
     private fun initModifyClickListener() {
         binding.ivMyPageEdit.setSingleOnClickListener {
-            Intent(requireActivity(), ProfileModifyActivity::class.java).apply {
-                putExtra(USER_INFO, myPageViewModel.userData.value)
-            }.also { intent ->
-                startActivity(intent)
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                Toast.makeText(requireContext(), "기능 준비 중이에요.", Toast.LENGTH_SHORT).show()
+            } else {
+                Intent(requireActivity(), ProfileModifyActivity::class.java).apply {
+                    putExtra(USER_INFO, myPageViewModel.userData.value)
+                }.also { intent ->
+                    startActivity(intent)
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="my_page_developer_info_link">https://interesting-door-b57.notion.site/About-Team-b25424073add46b9a186d69c17815bf2</string>
     <string name="my_page_policy_link">https://interesting-door-b57.notion.site/d00db57d23414511ad8ec1f2f24c230a</string>
     <string name="my_page_ask_link">https://walla.my/survey/inPmakCKv1iE39DMrg8Z</string>
+    <string name="my_page_28_donot_modify">해당 기기에서는 지원하지 않는 기능입니다</string>
 
     <!-- Book Recommendation-->
     <string name="recommendation_book_comment_count">%d/200</string>


### PR DESCRIPTION
관련 이슈
- closed #263 

작업 사진/동영상 (선택)
- 

작업한 내용
- 28이하에서는 프로필 수정뷰로의 진입 막고, 토스트 메세지 띄우기
- 29이상에서는 정상 작동

PR 포인트
- 분기처리
