### PR TITLE
#310 [ui] 책 0권일 때 픽 수정하기 버튼 안보이게 수정

### DIFF
--- a/app/src/main/res/layout/fragment_bookshelf.xml
+++ b/app/src/main/res/layout/fragment_bookshelf.xml
@@ -249,14 +249,13 @@
                     android:layout_marginTop="@dimen/btn_bookshelf_recommend_top_margin"
                     android:layout_marginEnd="20dp"
                     android:background="@drawable/shape_white40fill_redline_rect"
-                    android:clickable="@{(vm.bookTotalNum == 0) ? false : true}"
                     android:minWidth="0dp"
                     android:minHeight="0dp"
                     android:paddingHorizontal="9dp"
                     android:paddingVertical="5dp"
                     android:text="@string/bookshelf_modify_pick"
                     android:textColor="@color/peeka_red"
-                    android:visibility="@{vm.friendShelf == true ? View.INVISIBLE : View.VISIBLE}"
+                    android:visibility="@{vm.friendShelf == true || vm.bookTotalNum == 0 ? View.INVISIBLE : View.VISIBLE}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/ll_bookshelf_self_intro" />
 


### PR DESCRIPTION
관련 이슈
- closed #310 

작업 사진/동영상 (선택)
-
![Screenshot_20240323-140033](https://github.com/team-peekabook/Peekabook-AOS/assets/101049601/c492fe83-f544-4f6b-a2c7-8416a1973612)
![Screenshot_20240323-140042](https://github.com/team-peekabook/Peekabook-AOS/assets/101049601/5bd4acd4-f9dd-427c-8ad2-f09b7ddd7e1a)


작업한 내용
- 책 0권일 때 픽 수정하기 버튼 안보이게 수정

PR 포인트
- 간단하게 확인해주세용
