### PR TITLE
sdk 36 대응, edge to edge 대응, [책 등록] 키보드 활성화 시 뷰 가려짐 현상 수정, 토큰 재발급 시 발생하던 Retrofit response still open 에러 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,14 +15,14 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 
 android {
     namespace 'com.sopt.peekabookaos'
-    compileSdk 34
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.sopt.peekabookaos"
         minSdk 28
-        targetSdk 34
-        versionCode 13
-        versionName "1.4.0"
+        targetSdk 36
+        versionCode 14
+        versionName "1.4.1"
 
         buildConfigField "String", "NAVER_URL", properties["NAVER_URL"]
         buildConfigField "String", "CLIENT_ID", properties["CLIENT_ID"]

--- a/app/src/main/java/com/sopt/peekabookaos/di/RefreshRetrofitModule.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/di/RefreshRetrofitModule.kt
@@ -58,13 +58,13 @@ object RefreshRetrofitModule {
             .connectTimeout(10, TimeUnit.SECONDS)
             .writeTimeout(10, TimeUnit.SECONDS)
             .readTimeout(5, TimeUnit.SECONDS)
-            .addInterceptor(interceptor)
             .addInterceptor(
                 HttpLoggingInterceptor().apply {
                     level =
                         if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
                 }
             )
+            .addInterceptor(interceptor)
             .build()
 
     @Provides

--- a/app/src/main/java/com/sopt/peekabookaos/di/RetrofitModule.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/di/RetrofitModule.kt
@@ -85,12 +85,11 @@ object RetrofitModule {
                 if (originalRequest.header(RETRY_HEADER) != null) {
                     return@Interceptor response
                 }
-
-                response.close() // ★ 이전 응답 확실히 닫기
-
                 val refreshResult = runBlocking { refreshRepository.getRefreshToken() }
 
                 if (refreshResult.isSuccess) {
+                    response.close() // 이전 응답 확실히 닫기
+
                     // 새 토큰으로 다시 요청 — 재시도 플래그 달기
                     val newRequest = originalRequest.newBuilder()
                         .addHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -126,13 +125,14 @@ object RetrofitModule {
             .connectTimeout(10, TimeUnit.SECONDS)
             .writeTimeout(10, TimeUnit.SECONDS)
             .readTimeout(10, TimeUnit.SECONDS)
-            .addInterceptor(interceptor)
             .addInterceptor(
                 HttpLoggingInterceptor().apply {
                     level =
                         if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
                 }
-            ).build()
+            )
+            .addInterceptor(interceptor)
+            .build()
 
     /** ------------------------------------------------------------------
      *  Retrofit

--- a/app/src/main/java/com/sopt/peekabookaos/presentation/createBook/CreateBookFragment.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/presentation/createBook/CreateBookFragment.kt
@@ -73,6 +73,11 @@ class CreateBookFragment :
             return@setOnTouchListener false
         }
 
+        binding.svCreateBook.setOnTouchListener { _, _ ->
+            KeyBoardUtil.hide(activity = requireActivity())
+            return@setOnTouchListener false
+        }
+
         binding.btnCreateBookSave.setOnTouchListener { _, _ ->
             KeyBoardUtil.hide(activity = requireActivity())
             return@setOnTouchListener false

--- a/app/src/main/java/com/sopt/peekabookaos/util/binding/BindingActivity.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/util/binding/BindingActivity.kt
@@ -1,8 +1,11 @@
 package com.sopt.peekabookaos.util.binding
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 
@@ -13,7 +16,14 @@ abstract class BindingActivity<T : ViewDataBinding>(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = DataBindingUtil.setContentView(this, layoutRes)
         binding.lifecycleOwner = this
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
     }
 }

--- a/app/src/main/java/com/sopt/peekabookaos/util/binding/BindingActivity.kt
+++ b/app/src/main/java/com/sopt/peekabookaos/util/binding/BindingActivity.kt
@@ -22,7 +22,9 @@ abstract class BindingActivity<T : ViewDataBinding>(
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+            val maxBottom = Math.max(systemBars.bottom, ime.bottom)
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, maxBottom)
             insets
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.enableJetifier=true
+
+# Suppress warning for compileSdk 36 on AGP 8.1.1
+android.suppressUnsupportedCompileSdk=36


### PR DESCRIPTION
관련 이슈
- closed #339 

작업 사진/동영상 (선택)
-
x

작업한 내용
- 
feat: Edge-to-Edge 키보드 대응 및 Retrofit 인터셉터 에러 수정
BindingActivity
: Edge-to-Edge 모드에서 키보드(IME) 높이를 감지하여 하단 패딩 동적 적용

CreateBookFragment
: 배경 터치 시 키보드 숨김 기능 추가
AndroidManifest: 주요 액티비티에 adjustResize 설정 추가
RetrofitModule: 토큰 재발급 시 응답 미폐쇄로 인한 IllegalStateException 수정 및 인터셉터 순서 조정

gradle.properties
: compileSdk 36 관련 경고 억제 옵션 추가

PR 포인트
- 
x